### PR TITLE
Update events-carousel

### DIFF
--- a/cs-expo-2023/app/events/cs-expo/page.tsx
+++ b/cs-expo-2023/app/events/cs-expo/page.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
+import Carousel from "@/components/Carousel";
 import PhotoComponent from "@/components/PhotoComponent";
 import AboutComponent from "@/components/AboutComponent";
 import ButtonComponent from "@/components/ButtonComponent";
-import SpeakerPanelistLayout from '../../../components/SpeakerPanelistLayout'; 
-
+import SpeakerPanelistLayout from "../../../components/SpeakerPanelistLayout";
 
 export const EventsCSExpo = () => {
     const [currentButton, setCurrentButton] = useState(1);
 
-    const changeButton = (buttonNumber: number) => { 
+    const changeButton = (buttonNumber: number) => {
         setCurrentButton(buttonNumber);
     };
 
@@ -24,7 +24,7 @@ export const EventsCSExpo = () => {
         "PANELIST 7",
         "PANELIST 8",
     ];
-    
+
     const photoNumber = [
         "Photo 1",
         "Photo 2",
@@ -35,7 +35,7 @@ export const EventsCSExpo = () => {
         "Photo 7",
         "Photo 8",
     ];
-    
+
     const speakerProfession = [
         "Software Engineer",
         "Software Analyst",
@@ -46,7 +46,7 @@ export const EventsCSExpo = () => {
         "Data Scientist",
         "Software Consultant",
     ];
-    
+
     const intOrExt = [
         "INTERNAL",
         "EXTERNAL",
@@ -58,164 +58,70 @@ export const EventsCSExpo = () => {
         "EXTERNAL",
     ];
 
-    useEffect(() => {
-        const config = {
-            type: "carousel",
-            startAt: 0,
-            perView: 2,
-        };
-        new Glide(".carousel-2022", config).mount();
-        new Glide(".carousel-2023", config).mount();
-    }, []); 
-
     return (
         <main className="flex min-h-screen flex-col p-24">
-        <div className="container">
-            <PhotoComponent 
-                    currentButton={currentButton}
-                    customText="CS EXPO Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+            <PhotoComponent
+                currentButton={currentButton}
+                customText="CS EXPO Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
                     sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
                     sunt in culpa qui officia deserunt mollit anim id est laborum."
-                />
-            <ButtonComponent 
-                    currentButton={currentButton} 
-                    changeButton={changeButton} 
-                />
-                <h1 className="font-black text-8xl text-center mb-20">CS EXPO</h1>
-                <hr className="border-t-1 border-black mb-4" />
+            />
+            <ButtonComponent
+                currentButton={currentButton}
+                changeButton={changeButton}
+            />
+            <h1 className="font-black text-8xl text-center mb-20">CS EXPO</h1>
+            <hr className="border-t-1 border-black mb-4" />
             <AboutComponent
-                    customText="CS EXPO Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+                customText="CS EXPO Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
                     sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
                     Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
                     CS EXPO Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
                     sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
                     Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-                    
-                    sampleText="Sample Photo"
-                />
+                sampleText="Sample Photo"
+            />
 
             <SpeakerPanelistLayout
-                    speakerNames={speakerNames}
-                    photoNumber={photoNumber}
-                    speakerProfession={speakerProfession}
-                    intOrExt={intOrExt}
-                    panelOrSpeaker="PANELIST"
-                  />
+                speakerNames={speakerNames}
+                photoNumber={photoNumber}
+                speakerProfession={speakerProfession}
+                intOrExt={intOrExt}
+                panelOrSpeaker="PANELIST"
+            />
 
-                <h1 className="font-black text-8xl">PREVIOUS DEV DAYS</h1>
-                <div className="grid grid-cols-12 mt-8 me-12">
-                    <div className="col-span-3">
-                        <h1 className="font-bold text-5xl">2022</h1>
-                        <p className="font-medium pe-12">
-                            Lorem ipsum dolor sit amet consectetur adipisicing
-                            elit.
-                        </p>
-                    </div>
-                    <div className="col-span-9 relative">
-                        <div className="carousel-2022 glide w-full overflow-hidden">
-                            <div className="glide__track" data-glide-el="track">
-                                <ul className="glide__slides flex">
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    ></li>
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    ></li>
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    ></li>
-                                </ul>
-                            </div>
-                            <div
-                                data-glide-el="controls"
-                                style={{ color: "var(--coral-pink)" }}
-                            >
-                                <button
-                                    data-glide-dir="<"
-                                    className="absolute top-16 -left-12 mt-4  text-5xl font-bold"
-                                >
-                                    {"<"}
-                                </button>
-                                <button
-                                    data-glide-dir=">"
-                                    className="absolute top-16 -right-12 mt-4 text-5xl font-bold"
-                                >
-                                    {">"}
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className="grid grid-cols-12 mt-8 me-12">
-                    <div className="col-span-3">
-                        <h1 className="font-bold text-5xl">2022</h1>
-                        <p className="font-medium pe-12">
-                            Lorem ipsum dolor sit amet consectetur adipisicing
-                            elit.
-                        </p>
-                    </div>
-                    <div className="col-span-9 relative">
-                        <div className="carousel-2023 glide w-full overflow-hidden">
-                            <div className="glide__track" data-glide-el="track">
-                                <ul className="glide__slides flex">
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    ></li>
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    ></li>
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    ></li>
-                                </ul>
-                            </div>
-                            <div
-                                data-glide-el="controls"
-                                style={{ color: "var(--coral-pink)" }}
-                            >
-                                <button
-                                    data-glide-dir="<"
-                                    className="absolute top-16 -left-12 mt-4  text-5xl font-bold"
-                                >
-                                    {"<"}
-                                </button>
-                                <button
-                                    data-glide-dir=">"
-                                    className="absolute top-16 -right-12 mt-4 text-5xl font-bold"
-                                >
-                                    {">"}
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            <div className="ms-28">
+                <h1 className="font-black text-8xl">PREVIOUS CS EXPOS</h1>
+
+                {/* 2022 */}
+                <Carousel
+                    title="2022"
+                    description="Lorem ipsum dolor sit amet consectetur adipisicing elit."
+                    // Don't forget to change the type of the slides in the Carousel component when changing it to photos
+                    slides={[
+                        { backgroundColor: "var(--timberwolf)" },
+                        { backgroundColor: "var(--timberwolf)" },
+                        { backgroundColor: "var(--timberwolf)" },
+                    ]}
+                    perView={2}
+                    id="carousel-2022"
+                />
+
+                {/* 2023 */}
+                <Carousel
+                    title="2023"
+                    description="Lorem ipsum dolor sit amet consectetur adipisicing elit."
+                    slides={[
+                        { backgroundColor: "var(--timberwolf)" },
+                        { backgroundColor: "var(--timberwolf)" },
+                        { backgroundColor: "var(--timberwolf)" },
+                    ]}
+                    perView={2}
+                    id="carousel-2023"
+                />
             </div>
         </main>
     );
-  };
+};
 
 export default EventsCSExpo;

--- a/cs-expo-2023/app/events/dev-day/page.tsx
+++ b/cs-expo-2023/app/events/dev-day/page.tsx
@@ -1,9 +1,10 @@
-'use client'
-import React, { useState, useEffect } from "react";
+"use client";
+import React, { useState } from "react";
+import Carousel from "@/components/Carousel";
 import PhotoComponent from "@/components/PhotoComponent";
 import AboutComponent from "@/components/AboutComponent";
 import ButtonComponent from "@/components/ButtonComponent";
-import SpeakerPanelistLayout from '../../../components/SpeakerPanelistLayout'; 
+import SpeakerPanelistLayout from "../../../components/SpeakerPanelistLayout";
 
 export const EventsDevDay = () => {
     const [currentButton, setCurrentButton] = useState(1);
@@ -57,52 +58,41 @@ export const EventsDevDay = () => {
         "EXTERNAL",
     ];
 
-    const description = [
-        "Photo 1",
-        "Photo 2",
-        "Photo 3",
-        "Photo 4",
-    ];
+    const description = ["Photo 1", "Photo 2", "Photo 3", "Photo 4"];
 
     const changeSpeaker = (direction) => {
         if (direction === "above") {
-            setCurrentIndex((prevIndex) => (prevIndex - 1 >= 0 ? prevIndex - 1 : speakerNames.length - 1));
+            setCurrentIndex((prevIndex) =>
+                prevIndex - 1 >= 0 ? prevIndex - 1 : speakerNames.length - 1
+            );
         } else if (direction === "below") {
-            setCurrentIndex((prevIndex) => (prevIndex + 1 < speakerNames.length ? prevIndex + 1 : 0));
+            setCurrentIndex((prevIndex) =>
+                prevIndex + 1 < speakerNames.length ? prevIndex + 1 : 0
+            );
         }
     };
 
-    useEffect(() => {
-        const config = {
-            type: "carousel",
-            startAt: 0,
-            perView: 2,
-        };
-        const glide2022 = new Glide(".carousel-2022", config);
-        glide2022.mount();
-        const glide2023 = new Glide(".carousel-2023", config);
-        glide2023.mount();
-    }, []);
-
     return (
-        <main className="flex min-h-screen flex-col p-24">    
+        <main className="flex min-h-screen flex-col p-24">
             <div className="ms-28">
                 <div className="container">
-                    <PhotoComponent 
+                    <PhotoComponent
                         currentButton={currentButton}
                         customText="DEV DAY Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. sunt in culpa qui officia deserunt mollit anim id est laborum."
                     />
-                    <ButtonComponent 
-                        currentButton={currentButton} 
-                        changeButton={changeButton} 
+                    <ButtonComponent
+                        currentButton={currentButton}
+                        changeButton={changeButton}
                     />
-                    <h1 className="font-black text-8xl text-center mb-20">DEV DAY</h1>
+                    <h1 className="font-black text-8xl text-center mb-20">
+                        DEV DAY
+                    </h1>
                     <hr className="border-t-1 border-black mb-4" />
                     <AboutComponent
                         customText="DEV DAY Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
                         sampleText="Sample Photo"
                     />
-                    
+
                     <SpeakerPanelistLayout
                         speakerNames={speakerNames}
                         photoNumber={photoNumber}
@@ -110,123 +100,39 @@ export const EventsDevDay = () => {
                         intOrExt={intOrExt}
                         panelOrSpeaker="SPEAKER"
                     />
-
                 </div>
             </div>
 
             <div className="ms-28">
                 <h1 className="font-black text-8xl">PREVIOUS DEV DAYS</h1>
-                <div className="grid grid-cols-12 mt-8 me-12">
-                    <div className="col-span-3">
-                        <h1 className="font-bold text-5xl">2022</h1>
-                        <p className="font-medium pe-12">
-                            Lorem ipsum dolor sit amet consectetur adipisicing
-                            elit.
-                        </p>
-                    </div>
-                    <div className="col-span-9 relative">
-                        <div className="carousel-2022 glide w-full overflow-hidden">
-                            <div className="glide__track" data-glide-el="track">
-                                <ul className="glide__slides flex">
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    />
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    />
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    />
-                                </ul>
-                            </div>
-                            <div
-                                data-glide-el="controls"
-                                style={{ color: "var(--coral-pink)" }}
-                            >
-                                <button
-                                    data-glide-dir="<"
-                                    className="absolute top-16 -left-12 mt-4  text-5xl font-bold"
-                                >
-                                    {"<"}
-                                </button>
-                                <button
-                                    data-glide-dir=">"
-                                    className="absolute top-16 -right-12 mt-4 text-5xl font-bold"
-                                >
-                                    {">"}
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div className="grid grid-cols-12 mt-8 me-12">
-                    <div className="col-span-3">
-                        <h1 className="font-bold text-5xl">2023</h1>
-                        <p className="font-medium pe-12">
-                            Lorem ipsum dolor sit amet consectetur adipisicing
-                            elit.
-                        </p>
-                    </div>
-                    <div className="col-span-9 relative">
-                        <div className="carousel-2023 glide w-full overflow-hidden">
-                            <div className="glide__track" data-glide-el="track">
-                                <ul className="glide__slides flex">
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    />
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    />
-                                    <li
-                                        className="glide__slide w-120 h-52"
-                                        style={{
-                                            backgroundColor:
-                                                "var(--timberwolf)",
-                                        }}
-                                    />
-                                </ul>
-                            </div>
-                            <div
-                                data-glide-el="controls"
-                                style={{ color: "var(--coral-pink)" }}
-                            >
-                                <button
-                                    data-glide-dir="<"
-                                    className="absolute top-16 -left-12 mt-4  text-5xl font-bold"
-                                >
-                                    {"<"}
-                                </button>
-                                <button
-                                    data-glide-dir=">"
-                                    className="absolute top-16 -right-12 mt-4 text-5xl font-bold"
-                                >
-                                    {">"}
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-             </div>
+
+                {/* 2022 */}
+                <Carousel
+                    title="2022"
+                    description="Lorem ipsum dolor sit amet consectetur adipisicing elit."
+                    // Don't forget to change the type of the slides in the Carousel component when changing it to photos
+                    slides={[
+                        { backgroundColor: "var(--timberwolf)" },
+                        { backgroundColor: "var(--timberwolf)" },
+                        { backgroundColor: "var(--timberwolf)" },
+                    ]}
+                    perView={2}
+                    id="carousel-2022"
+                />
+
+                {/* 2023 */}
+                <Carousel
+                    title="2023"
+                    description="Lorem ipsum dolor sit amet consectetur adipisicing elit."
+                    slides={[
+                        { backgroundColor: "var(--timberwolf)" },
+                        { backgroundColor: "var(--timberwolf)" },
+                        { backgroundColor: "var(--timberwolf)" },
+                    ]}
+                    perView={2}
+                    id="carousel-2023"
+                />
+            </div>
         </main>
     );
 };

--- a/cs-expo-2023/components/Carousel.tsx
+++ b/cs-expo-2023/components/Carousel.tsx
@@ -27,33 +27,32 @@ const Carousel: React.FC<CarouselProps> = ({
             type: "carousel",
             startAt: 0,
             perView: perView || 3,
+            autoplay: 2000,
         };
         new Glide(`#${id}`, config).mount();
     }, []);
 
     return (
-        <div className="grid grid-cols-12 mt-8 me-12">
+        <div className="grid grid-cols-12 mt-8 me-12 h-[200px]">
             <div className="col-span-3">
                 <h1 className="font-bold text-5xl">{title}</h1>
                 <p className="font-medium pe-12">{description}</p>
             </div>
             <div className="col-span-9 relative">
-                <div
-                    className={`carousel-${id} glide w-full overflow-hidden`}
-                    id={id}
-                >
-                    <div className="glide__track" data-glide-el="track">
+                <div className={`${id} h-full glide overflow-hidden`} id={id}>
+                    <div className="glide__trackh-full" data-glide-el="track">
                         <ul className="glide__slides flex">
-                            {slides.map((slide, index) => (
-                                <li
-                                    key={index}
-                                    className="glide__slide w-120 h-52"
-                                    style={{
-                                        backgroundColor:
-                                            slide.backgroundColor ||
-                                            "var(--timberwolf)",
-                                    }}
-                                ></li>
+                            {slides.map((slide) => (
+                                <li className="glide__slide">
+                                    <div
+                                        className="w-[320px] h-[180px]"
+                                        style={{
+                                            backgroundColor:
+                                                slide.backgroundColor ||
+                                                "var(--timberwolf)",
+                                        }}
+                                    ></div>
+                                </li>
                             ))}
                         </ul>
                     </div>
@@ -63,7 +62,7 @@ const Carousel: React.FC<CarouselProps> = ({
                     >
                         <button
                             data-glide-dir="<"
-                            className="absolute top-16 -left-12 mt-4 text-5xl font-bold"
+                            className="absolute top-10 -left-12 mt-4 text-5xl font-bold"
                         >
                             <span className="flex-auto">
                                 <AiOutlineLeft />
@@ -71,7 +70,7 @@ const Carousel: React.FC<CarouselProps> = ({
                         </button>
                         <button
                             data-glide-dir=">"
-                            className="absolute top-16 -right-12 mt-4 text-5xl font-bold"
+                            className="absolute top-10 -right-12 mt-4 text-5xl font-bold"
                         >
                             <span className="flex-auto">
                                 <AiOutlineRight />


### PR DESCRIPTION
**Changes:**
- Updated the CS Expo and Dev Day's pages to the latest carousel(uses carousel's component).
- Images are now in fixed size regardless of your zoom size.
- Added autoplay on carousel.

**Issues:**
- The event pages' header, about section, and panelists/speakers section are not properly responsive.
![Screenshot (406)](https://github.com/yanaagi/cs-expo-2023/assets/18277662/b389f907-b15d-4ca3-8f58-ca0d737f4737)
_This is what I see on my laptop's chrome (zoom: 100%)_
![image](https://github.com/yanaagi/cs-expo-2023/assets/18277662/f6809379-349d-4fdd-9e59-3684872c295f)
_This is what I see on my laptop's chrome (zoom: 25%). Just to see that header photo's size is not fixed and some are not centered_