### PR TITLE
fix: remove conflicting & unused CSS in globals.css

### DIFF
--- a/cs-expo-2023/app/globals.css
+++ b/cs-expo-2023/app/globals.css
@@ -20,19 +20,4 @@
         --background-end-rgb: 0, 0, 0;
     }
 }
-
-/* Adds CSS to ThesisPosterCard component */
-@keyframes fadeIn {
-    from {
-      opacity: 0; /* Start with 0 opacity (completely transparent) */
-    }
-    to {
-      opacity: 1; /* End with 1 opacity (fully visible) */
-    }
-  }
-  
-  /* Apply the "fadeIn" animation to the images */
-  img {
-    animation: fadeIn 2s; /* Use the "fadeIn" animation with a 2-second duration */
-  }
   


### PR DESCRIPTION
apologies for my mistake, i should have removed these lines sooner in globals.css. they are not needed anymore because this was for the old version of projects overview with actual thesis posters.

![image](https://github.com/yanaagi/cs-expo-2023/assets/50406636/2f2ba734-6e11-415e-8c8d-838873bc6d31)
